### PR TITLE
De-duplicate displayName, remove from Profile.

### DIFF
--- a/group-collaboration/src/components/Firebase/firebase.js
+++ b/group-collaboration/src/components/Firebase/firebase.js
@@ -20,13 +20,25 @@ export default class Firebase {
     this.db = app.firestore();
   }
 
+  setDisplayName = displayName =>
+    this.auth.currentUser.updateProfile({ displayName });
+
   doCreateUserWithEmailAndPassword = (email, password) =>
     this.auth
       .createUserWithEmailAndPassword(email, password)
-      .then(userCredential => {
+      .then(() => {
+        /* Set the display name on the auth currentUser object */
         const displayName = this.auth.currentUser.email.split("@")[0];
-        this.auth.currentUser.updateProfile({ displayName });
-        return Promise.resolve(userCredential);
+        return this.setDisplayName(displayName);
+      })
+      .then(() => {
+        /* Create the initial profile document */
+        return this.db
+          .collection(process.env.REACT_APP_PROFILES_COLLECTION)
+          .doc(this.auth.currentUser.uid)
+          .set({
+            description: ""
+          });
       });
 
   doSignInWithEmailAndPassword = (email, password) =>
@@ -35,7 +47,6 @@ export default class Firebase {
   doSignOut = () => this.auth.signOut();
 
   sendPasswordResetEmail = email => this.auth.sendPasswordResetEmail(email);
-
 
   getProjects = () =>
     this.db

--- a/group-collaboration/src/components/ProfileEditor/nameEditor.js
+++ b/group-collaboration/src/components/ProfileEditor/nameEditor.js
@@ -1,40 +1,34 @@
-import React, {useState, useContext, useEffect} from 'react'
-import {FirebaseContext} from '../Firebase'
+import React, { useState, useContext, useEffect } from "react";
+import { FirebaseContext } from "../Firebase";
 
 export default function() {
-  const firebase = useContext(FirebaseContext)
-  const [displayName, setDisplayName] = useState(firebase.auth.currentUser.displayName)
-  const [validated, setValidated] = useState(false)
+  const firebase = useContext(FirebaseContext);
+  const [displayName, setDisplayName] = useState(
+    firebase.auth.currentUser.displayName
+  );
+  const [validated, setValidated] = useState(false);
 
-  const [error, setError] = useState("")
+  const [error, setError] = useState("");
 
-  useEffect( () => {
-    setDisplayName(firebase.auth.currentUser.displayName)
-  }, [firebase.auth.currentUser.displayName])
+  useEffect(() => {
+    setDisplayName(firebase.auth.currentUser.displayName);
+  }, [firebase.auth.currentUser.displayName]);
 
-  useEffect( () => {
+  useEffect(() => {
     setValidated(
       displayName &&
-      displayName.length > 0 &&
-      displayName !== firebase.auth.currentUser.displayName)
-  }, [displayName, firebase.auth.currentUser.displayName])
+        displayName.length > 0 &&
+        displayName !== firebase.auth.currentUser.displayName
+    );
+  }, [displayName, firebase.auth.currentUser.displayName]);
 
-  // Copies the User displayName field into the adjunct profile document.
-  const syncProfile = (user) => {
-    firebase
-      .updateProfile(user.uid, {displayName: user.displayName})
-      .catch(setError)
-  }
+  const onSubmit = event => {
+    event.preventDefault();
 
-  const onSubmit = (event) => {
-    event.preventDefault()
+    setValidated(false);
 
-    setValidated(false)
-
-    firebase.auth.currentUser.updateProfile({ displayName })
-      .then(() => syncProfile(firebase.auth.currentUser))
-      .catch(setError)
-  }
+    firebase.setDisplayName(displayName).catch(setError);
+  };
 
   return (
     <div>
@@ -52,5 +46,5 @@ export default function() {
         {error && <p>{error.message}</p>}
       </form>
     </div>
-  )
+  );
 }

--- a/group-collaboration/src/components/SignUp/form.js
+++ b/group-collaboration/src/components/SignUp/form.js
@@ -1,43 +1,32 @@
-import React, {useState, useContext} from 'react'
-import {FirebaseContext} from '../Firebase'
-import {useHistory} from 'react-router-dom'
-import * as ROUTES from '../../constants/routes';
+import React, { useState, useContext } from "react";
+import { FirebaseContext } from "../Firebase";
+import { useHistory } from "react-router-dom";
+import * as ROUTES from "../../constants/routes";
 
 export default function() {
-  const history = useHistory()
-  const firebase = useContext(FirebaseContext)
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState("")
-  const [passwordConfirmation, setPasswordConfirmation] = useState("")
-  const [error, setError] = useState("")
+  const history = useHistory();
+  const firebase = useContext(FirebaseContext);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [error, setError] = useState("");
 
   const validate = () => {
     return (
       email.length > 0 &&
       password.length > 0 &&
       password === passwordConfirmation
-    )
-  }
+    );
+  };
 
-  const createAdjunctProfile = (user) =>
-    firebase.db
-      .collection(process.env.REACT_APP_PROFILES_COLLECTION)
-      .doc(user.uid)
-      .set( {
-        displayName: user.email.split('@')[0],
-        description: "",
-      })
-      .catch( error => setError(error) )
-
-  const onSubmit = (event) => {
+  const onSubmit = event => {
     event.preventDefault();
 
     firebase
       .doCreateUserWithEmailAndPassword(email, password)
-      .then( () => createAdjunctProfile(firebase.auth.currentUser) )
-      .then( () => history.push(ROUTES.EDIT_PROFILE) )
-      .catch( error => setError(error) )
-  }
+      .then(() => history.push(ROUTES.EDIT_PROFILE))
+      .catch(error => setError(error));
+  };
 
   return (
     <div>
@@ -66,5 +55,5 @@ export default function() {
         {error && <p>{error.message}</p>}
       </form>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
It's enough to have displayName only in the Users collection. Before this PR, the displayName property was duplicated across the Profile and User documents. With this PR there is one source of truth: the auth.currentUser.displayName property.