### PR TITLE
Refactor tests with TestProvider component

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,25 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
-import { ProviderContext } from "./components/Provider";
+import TestProvider from "./components/TestProvider";
 
 it("renders without crashing", () => {
   const div = document.createElement("div");
 
-  const provider = {
-    auth: {
-      currentUser: {
-        uid: 1,
-        displayName: "hi",
-        email: "hi@example.com"
-      }
-    }
-  };
-
   ReactDOM.render(
-    <ProviderContext.Provider value={provider}>
+    <TestProvider>
       <App />
-    </ProviderContext.Provider>,
+    </TestProvider>,
     div
   );
 });

--- a/src/components/FollowersViewer/index.test.js
+++ b/src/components/FollowersViewer/index.test.js
@@ -2,24 +2,18 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
 import FollowersViewer from "./index";
-import { ProviderContext } from "../Provider";
+import TestProvider, { mock } from "../TestProvider";
 
 it("renders without crashing", async () => {
   const div = document.createElement("div");
 
-  const fakebase = {
-    getProjectFollowers: id => {
-      return Promise.resolve([{ displayName: "me" }]);
-    }
-  };
-
   await act(async () => {
     ReactDOM.render(
-      <ProviderContext.Provider value={fakebase}>
+      <TestProvider>
         <FollowersViewer projectId="123" />
-      </ProviderContext.Provider>,
+      </TestProvider>,
       div
     );
   });
-  expect(div.innerHTML).toContain("me");
+  expect(div.innerHTML).toContain(mock.displayName);
 });

--- a/src/components/ForgotPassword/index.test.js
+++ b/src/components/ForgotPassword/index.test.js
@@ -2,33 +2,16 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
 import ForgotPassword from "./index";
-import { ProviderContext } from "../Provider";
-import { SessionContext } from "../Session";
-import { MemoryRouter } from "react-router-dom";
+import TestProvider from "../TestProvider";
 
 it("renders without crashing", async () => {
   const div = document.createElement("div");
 
-  const resetPromise = {
-    resolve: undefined,
-    reject: undefined
-  };
-
-  const fakebase = {
-    sendPasswordResetEmail: email =>
-      new Promise((resolve, reject) => {
-        resetPromise.resolve = resolve;
-        resetPromise.reject = reject;
-      })
-  };
-
   act(() => {
     ReactDOM.render(
-      <MemoryRouter>
-        <ProviderContext.Provider value={fakebase}>
-          <ForgotPassword />
-        </ProviderContext.Provider>
-      </MemoryRouter>,
+      <TestProvider>
+        <ForgotPassword />
+      </TestProvider>,
       div
     );
   });

--- a/src/components/Landing/index.test.js
+++ b/src/components/Landing/index.test.js
@@ -1,38 +1,17 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import { MemoryRouter } from "react-router-dom";
 import { act } from "react-dom/test-utils";
 import Landing from "./index";
-import { ProviderContext } from "../Provider";
-import { SessionContext } from "../Session";
+import TestProvider, { projectsPromise } from "../TestProvider";
 
 it("renders without crashing", async () => {
   const div = document.createElement("div");
 
-  const projectsPromise = {
-    resolve: undefined,
-    reject: undefined
-  };
-
-  const fakesession = { uid: "123" };
-
-  const fakebase = {
-    getProjects: () =>
-      new Promise((resolve, reject) => {
-        projectsPromise.resolve = resolve;
-        projectsPromise.reject = reject;
-      })
-  };
-
   act(() => {
     ReactDOM.render(
-      <MemoryRouter>
-        <ProviderContext.Provider value={fakebase}>
-          <SessionContext.Provider value={fakesession}>
-            <Landing />
-          </SessionContext.Provider>
-        </ProviderContext.Provider>
-      </MemoryRouter>,
+      <TestProvider>
+        <Landing />
+      </TestProvider>,
       div
     );
   });

--- a/src/components/MessageViewer/index.test.js
+++ b/src/components/MessageViewer/index.test.js
@@ -2,23 +2,16 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
 import MessageViewer from "./index";
-import { ProviderContext } from "../Provider";
+import TestProvider from "../TestProvider";
 
 it("renders without crashing", () => {
   const div = document.createElement("div");
 
-  const fakebase = {
-    subscribeProjectMessages: (id, callback, error) => {
-      callback([]); // respond with an empty array, i.e. no messages
-      return function() {};
-    }
-  };
-
   act(() => {
     ReactDOM.render(
-      <ProviderContext.Provider value={fakebase}>
+      <TestProvider>
         <MessageViewer />
-      </ProviderContext.Provider>,
+      </TestProvider>,
       div
     );
   });

--- a/src/components/NameTag/index.js
+++ b/src/components/NameTag/index.js
@@ -1,10 +1,12 @@
-import React from "react";
+import React, { useContext } from "react";
 import Button from "@material-ui/core/Button";
 import { useHistory } from "react-router-dom";
+import { SessionContext } from "../Session";
 import * as ROUTES from "../../constants/routes";
 
-export default function({ session }) {
+export default function() {
   const history = useHistory();
+  const session = useContext(SessionContext);
 
   const handleSignIn = event => {
     history.push(ROUTES.SIGN_IN);

--- a/src/components/NameTag/index.test.js
+++ b/src/components/NameTag/index.test.js
@@ -1,41 +1,34 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import { MemoryRouter } from "react-router-dom";
+
 import { act } from "react-dom/test-utils";
 import NameTag from "./index";
-import { SessionContext } from "../Session";
+import TestProvider, { mock } from "../TestProvider";
+
+let div;
+beforeEach(() => {
+  div = document.createElement("div");
+});
 
 it("renders valid session without crashing", async () => {
-  const fakesession = {
-    uid: "123",
-    displayName: "myDisplayName",
-    email: "my@email.example.com"
-  };
-
-  const div = document.createElement("div");
-
   act(() => {
     ReactDOM.render(
-      <MemoryRouter>
-        <NameTag session={fakesession} />
-      </MemoryRouter>,
+      <TestProvider>
+        <NameTag />
+      </TestProvider>,
       div
     );
   });
 
-  expect(div.textContent).toBe("myDisplayName");
+  expect(div.textContent).toBe(mock.displayName);
 });
 
 it("renders null session without crashing", async () => {
-  const fakesession = null;
-
-  const div = document.createElement("div");
-
   act(() => {
     ReactDOM.render(
-      <MemoryRouter>
-        <NameTag session={fakesession} />
-      </MemoryRouter>,
+      <TestProvider session={null}>
+        <NameTag />
+      </TestProvider>,
       div
     );
   });
@@ -44,15 +37,11 @@ it("renders null session without crashing", async () => {
 });
 
 it("renders undefined session without crashing", async () => {
-  const fakesession = undefined;
-
-  const div = document.createElement("div");
-
   act(() => {
     ReactDOM.render(
-      <MemoryRouter>
-        <NameTag session={fakesession} />
-      </MemoryRouter>,
+      <TestProvider session={undefined}>
+        <NameTag />
+      </TestProvider>,
       div
     );
   });

--- a/src/components/NavDrawer/index.test.js
+++ b/src/components/NavDrawer/index.test.js
@@ -1,37 +1,19 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import { MemoryRouter } from "react-router-dom";
 import { act } from "react-dom/test-utils";
 import NavDrawer from "./index";
-import { SessionContext } from "../Session";
+import TestProvider from "../TestProvider";
 
 it("renders without crashing", async () => {
   const div = document.createElement("div");
 
   const drawerOpen = false;
 
-  const fakesession = {
-    uid: "123",
-    displayName: "myDisplayName",
-    email: "my@email.example.com"
-  };
-
-  const signoutPromise = { resolve: undefined, reject: undefined };
-  const fakebase = {
-    doSignOut: () =>
-      new Promise((resolve, reject) => {
-        signoutPromise.resolve = resolve;
-        signoutPromise.reject = reject;
-      })
-  };
-
   act(() => {
     ReactDOM.render(
-      <MemoryRouter>
-        <SessionContext.Provider value={fakesession}>
-          <NavDrawer drawerOpen={drawerOpen} />
-        </SessionContext.Provider>
-      </MemoryRouter>,
+      <TestProvider>
+        <NavDrawer drawerOpen={drawerOpen} />
+      </TestProvider>,
       div
     );
   });

--- a/src/components/NewProject/form.test.js
+++ b/src/components/NewProject/form.test.js
@@ -1,28 +1,18 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import { MemoryRouter } from "react-router-dom";
 import { act } from "react-dom/test-utils";
+
 import NewProjectForm from "./form";
-import { ProviderContext } from "../Provider";
-import { SessionContext } from "../Session";
+import TestProvider from "../TestProvider";
 
 it("renders without crashing", () => {
   const div = document.createElement("div");
 
-  const fakebase = {};
-  const fakesession = {
-    uid: 123
-  };
-
   act(() => {
     ReactDOM.render(
-      <MemoryRouter>
-        <ProviderContext.Provider value={fakebase}>
-          <SessionContext.Provider value={fakesession}>
-            <NewProjectForm />
-          </SessionContext.Provider>
-        </ProviderContext.Provider>
-      </MemoryRouter>,
+      <TestProvider>
+        <NewProjectForm />
+      </TestProvider>,
       div
     );
   });

--- a/src/components/NewProject/index.test.js
+++ b/src/components/NewProject/index.test.js
@@ -1,28 +1,18 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import { MemoryRouter } from "react-router-dom";
 import { act } from "react-dom/test-utils";
+
 import NewProject from "./index";
-import { ProviderContext } from "../Provider";
-import { SessionContext } from "../Session";
+import TestProvider from "../TestProvider";
 
 it("renders without crashing", () => {
   const div = document.createElement("div");
 
-  const fakebase = {};
-  const fakesession = {
-    uid: 123
-  };
-
   act(() => {
     ReactDOM.render(
-      <MemoryRouter>
-        <ProviderContext.Provider value={fakebase}>
-          <SessionContext.Provider value={fakesession}>
-            <NewProject />
-          </SessionContext.Provider>
-        </ProviderContext.Provider>
-      </MemoryRouter>,
+      <TestProvider>
+        <NewProject />
+      </TestProvider>,
       div
     );
   });

--- a/src/components/ProfileEditor/index.test.js
+++ b/src/components/ProfileEditor/index.test.js
@@ -1,49 +1,17 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
-import { MemoryRouter } from "react-router-dom";
 import ProfileEditor from "./index";
-import { ProviderContext } from "../Provider";
-import { SessionContext } from "../Session";
+import TestProvider from "../TestProvider";
 
 it("renders without crashing", () => {
   const div = document.createElement("div");
 
-  const fakesession = {
-    uid: 123
-  };
-
-  let signoutPromise, profilePromise;
-  signoutPromise = profilePromise = { resolve: undefined, reject: undefined };
-
-  const fakebase = {
-    doSignOut: () =>
-      new Promise((resolve, reject) => {
-        signoutPromise.resolve = resolve;
-        signoutPromise.reject = reject;
-      }),
-    getProfile: id =>
-      new Promise((resolve, reject) => {
-        profilePromise.resolve = resolve;
-        profilePromise.reject = reject;
-      }),
-    auth: {
-      currentUser: {
-        emailVerified: true,
-        email: "groopa@groopa.com"
-      }
-    }
-  };
-
   act(() => {
     ReactDOM.render(
-      <MemoryRouter>
-        <ProviderContext.Provider value={fakebase}>
-          <SessionContext.Provider value={fakesession}>
-            <ProfileEditor />
-          </SessionContext.Provider>
-        </ProviderContext.Provider>
-      </MemoryRouter>,
+      <TestProvider>
+        <ProfileEditor />
+      </TestProvider>,
       div
     );
   });

--- a/src/components/ProfileViewer/index.test.js
+++ b/src/components/ProfileViewer/index.test.js
@@ -2,34 +2,16 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
 import ProfileViewer from "./index";
-import { ProviderContext } from "../Provider";
-import { SessionContext } from "../Session";
+import TestProvider, { profilePromise } from "../TestProvider";
 
 it("renders without crashing", async () => {
   const div = document.createElement("div");
 
   const fakeprofile_id = "hij456";
 
-  const fakesession = {
-    uid: 123
-  };
-
   const fakeProfile = {
     displayName: "Amanda Huggenkis",
     description: "I am a mock person."
-  };
-
-  const profilePromise = {
-    resolve: undefined,
-    reject: undefined
-  };
-
-  const fakebase = {
-    getProfile: id =>
-      new Promise((resolve, reject) => {
-        profilePromise.resolve = resolve;
-        profilePromise.reject = reject;
-      })
   };
 
   // This would be provided by the Router, taken from the URL.
@@ -37,11 +19,9 @@ it("renders without crashing", async () => {
 
   act(() => {
     ReactDOM.render(
-      <ProviderContext.Provider value={fakebase}>
-        <SessionContext.Provider value={fakesession}>
-          <ProfileViewer match={match} />
-        </SessionContext.Provider>
-      </ProviderContext.Provider>,
+      <TestProvider>
+        <ProfileViewer match={match} />
+      </TestProvider>,
       div
     );
   });

--- a/src/components/ProjectEditor/form.test.js
+++ b/src/components/ProjectEditor/form.test.js
@@ -2,16 +2,14 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
 import EditorForm from "./form";
-import { ProviderContext } from "../Provider";
-import { SessionContext } from "../Session";
+
+import TestProvider from "../TestProvider";
 
 it("renders without crashing", () => {
   const div = document.createElement("div");
 
   // This would be provided by the Router, taken from the URL.
   const match = { params: { id: "test-project-id" } };
-
-  const fakebase = {};
 
   const fakeproject_id = "abc123";
   const fakeproject = {
@@ -21,16 +19,10 @@ it("renders without crashing", () => {
     repoLink: "https://test.example.com/hi"
   };
 
-  const fakesession = {
-    uid: 123
-  };
-
   ReactDOM.render(
-    <ProviderContext.Provider value={fakebase}>
-      <SessionContext.Provider value={fakesession}>
-        <EditorForm projectId={fakeproject_id} project={fakeproject} />
-      </SessionContext.Provider>
-    </ProviderContext.Provider>,
+    <TestProvider>
+      <EditorForm projectId={fakeproject_id} project={fakeproject} />
+    </TestProvider>,
     div
   );
 });

--- a/src/components/ProjectEditor/index.test.js
+++ b/src/components/ProjectEditor/index.test.js
@@ -2,8 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
 import ProjectEditor from "./index";
-import { ProviderContext } from "../Provider";
-import { SessionContext } from "../Session";
+import TestProvider, { projectPromise } from "../TestProvider";
 
 it("renders without crashing", async () => {
   const div = document.createElement("div");
@@ -16,37 +15,14 @@ it("renders without crashing", async () => {
     repoLink: "https://test.example.com/hi"
   };
 
-  const fakesession = {
-    uid: 123
-  };
-
-  const projectPromise = {
-    resolve: undefined,
-    reject: undefined
-  };
-
-  const fakebase = {
-    getProject: id =>
-      new Promise((resolve, reject) => {
-        projectPromise.resolve = resolve;
-      }),
-
-    subscribeProjectMessages: (id, callback, error) => {
-      callback([]); // Return an empty list of messages.
-      return function() {};
-    }
-  };
-
   // This would be provided by the Router, taken from the URL.
   const match = { params: { id: fakeproject_id } };
 
   act(() => {
     ReactDOM.render(
-      <ProviderContext.Provider value={fakebase}>
-        <SessionContext.Provider value={fakesession}>
-          <ProjectEditor match={match} />
-        </SessionContext.Provider>
-      </ProviderContext.Provider>,
+      <TestProvider>
+        <ProjectEditor match={match} />
+      </TestProvider>,
       div
     );
   });

--- a/src/components/ProjectViewer/index.test.js
+++ b/src/components/ProjectViewer/index.test.js
@@ -2,8 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
 import ProjectViewer from "./index";
-import { ProviderContext } from "../Provider";
-import { SessionContext } from "../Session";
+import TestProvider, { projectPromise } from "../TestProvider";
 
 it("renders without crashing", async () => {
   const div = document.createElement("div");
@@ -16,41 +15,14 @@ it("renders without crashing", async () => {
     repoLink: "https://test.example.com/hi"
   };
 
-  const fakesession = {
-    uid: 123
-  };
-
-  const projectPromise = {
-    resolve: undefined,
-    reject: undefined
-  };
-
-  const fakebase = {
-    getProject: id =>
-      new Promise((resolve, reject) => {
-        projectPromise.resolve = resolve;
-      }),
-
-    subscribeProjectMessages: (id, callback, error) => {
-      callback([]); // Return an empty list of messages.
-      return function() {};
-    },
-
-    getProjectFollowers: id => {
-      return Promise.resolve([{ displayName: "me" }]);
-    }
-  };
-
   // This would be provided by the Router, taken from the URL.
   const match = { params: { id: fakeproject_id } };
 
   act(() => {
     ReactDOM.render(
-      <ProviderContext.Provider value={fakebase}>
-        <SessionContext.Provider value={fakesession}>
-          <ProjectViewer match={match} />
-        </SessionContext.Provider>
-      </ProviderContext.Provider>,
+      <TestProvider>
+        <ProjectViewer match={match} />
+      </TestProvider>,
       div
     );
   });

--- a/src/components/Projects/index.test.js
+++ b/src/components/Projects/index.test.js
@@ -2,30 +2,16 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
 import Projects from "./index";
-import { ProviderContext } from "../Provider";
+import TestProvider, { projectsPromise } from "../TestProvider";
 
 it("renders without crashing", async () => {
   const div = document.createElement("div");
 
-  const projectsPromise = {
-    resolve: undefined,
-    reject: undefined
-  };
-
-  const fakebase = {
-    auth: { currentUser: { uid: "123" } },
-    getProjects: () =>
-      new Promise((resolve, reject) => {
-        projectsPromise.resolve = resolve;
-        projectsPromise.reject = reject;
-      })
-  };
-
   act(() => {
     ReactDOM.render(
-      <ProviderContext.Provider value={fakebase}>
+      <TestProvider>
         <Projects />
-      </ProviderContext.Provider>,
+      </TestProvider>,
       div
     );
   });

--- a/src/components/SignIn/form.test.js
+++ b/src/components/SignIn/form.test.js
@@ -1,38 +1,18 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
+
 import SigninForm from "./form";
-import { ProviderContext } from "../Provider";
-import { SessionContext } from "../Session";
-import { MemoryRouter } from "react-router-dom";
+import TestProvider from "../TestProvider";
 
 it("renders without crashing", async () => {
   const div = document.createElement("div");
 
-  const fakesession = undefined;
-
-  const signinPromise = {
-    resolve: undefined,
-    reject: undefined
-  };
-
-  const fakebase = {
-    doSignInWithEmailAndPassword: (email, password) =>
-      new Promise((resolve, reject) => {
-        signinPromise.resolve = resolve;
-        SigninPromise.reject = reject;
-      })
-  };
-
   act(() => {
     ReactDOM.render(
-      <MemoryRouter>
-        <ProviderContext.Provider value={fakebase}>
-          <SessionContext.Provider value={fakesession}>
-            <SigninForm />
-          </SessionContext.Provider>
-        </ProviderContext.Provider>
-      </MemoryRouter>,
+      <TestProvider session={undefined}>
+        <SigninForm />
+      </TestProvider>,
       div
     );
   });

--- a/src/components/SignIn/index.test.js
+++ b/src/components/SignIn/index.test.js
@@ -1,38 +1,18 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
+
 import Signin from "./index";
-import { ProviderContext } from "../Provider";
-import { SessionContext } from "../Session";
-import { MemoryRouter } from "react-router-dom";
+import TestProvider from "../TestProvider";
 
 it("renders without crashing", async () => {
   const div = document.createElement("div");
 
-  const fakesession = undefined;
-
-  const signinPromise = {
-    resolve: undefined,
-    reject: undefined
-  };
-
-  const fakebase = {
-    doSignInWithEmailAndPassword: (email, password) =>
-      new Promise((resolve, reject) => {
-        signinPromise.resolve = resolve;
-        signinPromise.reject = reject;
-      })
-  };
-
   act(() => {
     ReactDOM.render(
-      <MemoryRouter>
-        <ProviderContext.Provider value={fakebase}>
-          <SessionContext.Provider value={fakesession}>
-            <Signin />
-          </SessionContext.Provider>
-        </ProviderContext.Provider>
-      </MemoryRouter>,
+      <TestProvider session={undefined}>
+        <Signin />
+      </TestProvider>,
       div
     );
   });

--- a/src/components/SignOut/index.test.js
+++ b/src/components/SignOut/index.test.js
@@ -2,29 +2,16 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
 import SignOut from "./index";
-import { ProviderContext } from "../Provider";
+import TestProvider from "../TestProvider";
 
 it("renders without crashing", async () => {
   const div = document.createElement("div");
 
-  const signoutPromise = {
-    resolve: undefined,
-    reject: undefined
-  };
-
-  const fakebase = {
-    doSignOut: () =>
-      new Promise((resolve, reject) => {
-        signoutPromise.resolve = resolve;
-        signoutPromise.reject = reject;
-      })
-  };
-
   act(() => {
     ReactDOM.render(
-      <ProviderContext.Provider value={fakebase}>
+      <TestProvider>
         <SignOut />
-      </ProviderContext.Provider>,
+      </TestProvider>,
       div
     );
   });

--- a/src/components/SignUp/index.test.js
+++ b/src/components/SignUp/index.test.js
@@ -2,37 +2,16 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
 import Signup from "./index";
-import { ProviderContext } from "../Provider";
-import { SessionContext } from "../Session";
-import { MemoryRouter } from "react-router-dom";
+import TestProvider from "../TestProvider";
 
 it("renders without crashing", async () => {
   const div = document.createElement("div");
 
-  const fakesession = undefined;
-
-  const signupPromise = {
-    resolve: undefined,
-    reject: undefined
-  };
-
-  const fakebase = {
-    doCreateUserWithEmailAndPassword: (email, password) =>
-      new Promise((resolve, reject) => {
-        signupPromise.resolve = resolve;
-        signupPromise.reject = reject;
-      })
-  };
-
   act(() => {
     ReactDOM.render(
-      <MemoryRouter>
-        <ProviderContext.Provider value={fakebase}>
-          <SessionContext.Provider value={fakesession}>
-            <Signup />
-          </SessionContext.Provider>
-        </ProviderContext.Provider>
-      </MemoryRouter>,
+      <TestProvider session={undefined}>
+        <Signup />
+      </TestProvider>,
       div
     );
   });

--- a/src/components/TestProvider/index.js
+++ b/src/components/TestProvider/index.js
@@ -1,0 +1,108 @@
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { ProviderContext } from "../Provider";
+import { SessionContext } from "../Session";
+
+let signoutPromise,
+  signinPromise,
+  signupPromise,
+  profilePromise,
+  projectPromise,
+  projectsPromise,
+  resetPromise;
+
+signoutPromise = signinPromise = signupPromise = profilePromise = projectPromise = projectsPromise = resetPromise = {
+  resolve: undefined,
+  reject: undefined
+};
+
+const mock = {
+  displayName: "mockDisplayName",
+  email: "mock@email.com"
+};
+
+const mockSession = {
+  uid: 123,
+  displayName: mock.displayName,
+  email: mock.email
+};
+
+const TestProvider = props => {
+  // This bit allows us to explictly pass in falsy values for session
+  const fakeSession = Object.keys(props).includes("session")
+    ? props.session
+    : mockSession;
+
+  const fakebase = {
+    auth: {
+      currentUser: {
+        uid: 1,
+        displayName: mock.displayName,
+        emailVerified: true,
+        email: mock.email
+      }
+    },
+    doCreateUserWithEmailAndPassword: (email, password) =>
+      new Promise((resolve, reject) => {
+        signupPromise.resolve = resolve;
+        signupPromise.reject = reject;
+      }),
+    doSignInWithEmailAndPassword: (email, password) =>
+      new Promise((resolve, reject) => {
+        signinPromise.resolve = resolve;
+        SigninPromise.reject = reject;
+      }),
+    doSignOut: () =>
+      new Promise((resolve, reject) => {
+        signoutPromise.resolve = resolve;
+        signoutPromise.reject = reject;
+      }),
+    getProfile: id =>
+      new Promise((resolve, reject) => {
+        profilePromise.resolve = resolve;
+        profilePromise.reject = reject;
+      }),
+    getProject: id =>
+      new Promise((resolve, reject) => {
+        projectPromise.resolve = resolve;
+      }),
+    getProjectFollowers: id => {
+      return Promise.resolve([{ displayName: mock.displayName }]);
+    },
+    getProjects: () =>
+      new Promise((resolve, reject) => {
+        projectsPromise.resolve = resolve;
+        projectsPromise.reject = reject;
+      }),
+    sendPasswordResetEmail: email =>
+      new Promise((resolve, reject) => {
+        resetPromise.resolve = resolve;
+        resetPromise.reject = reject;
+      }),
+
+    subscribeProjectMessages: (id, callback, error) => {
+      callback([]); // Return an empty list of messages.
+      return function() {};
+    }
+  };
+
+  return (
+    <MemoryRouter>
+      <ProviderContext.Provider value={fakebase}>
+        <SessionContext.Provider value={fakeSession}>
+          {props.children}
+        </SessionContext.Provider>
+      </ProviderContext.Provider>
+    </MemoryRouter>
+  );
+};
+
+export {
+  projectPromise,
+  profilePromise,
+  signoutPromise,
+  projectsPromise,
+  resetPromise,
+  mock
+};
+export default TestProvider;

--- a/src/components/TopBar/index.js
+++ b/src/components/TopBar/index.js
@@ -133,7 +133,7 @@ export default function(props) {
           </div>
           <div className={classes.grow} />
           <div>
-            <NameTag session={session} />
+            <NameTag />
           </div>
         </Toolbar>
       </AppBar>

--- a/src/components/TopBar/index.test.js
+++ b/src/components/TopBar/index.test.js
@@ -1,28 +1,20 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import { MemoryRouter } from "react-router-dom";
+
 import { act } from "react-dom/test-utils";
 import TopBar from "./index";
-import { SessionContext } from "../Session";
+import TestProvider from "../TestProvider";
 
 it("renders without crashing", async () => {
   const div = document.createElement("div");
 
   const drawerOpen = false;
 
-  const fakesession = {
-    uid: "123",
-    displayName: "myDisplayName",
-    email: "my@email.example.com"
-  };
-
   act(() => {
     ReactDOM.render(
-      <MemoryRouter>
-        <SessionContext.Provider value={fakesession}>
-          <TopBar drawerOpen={drawerOpen} />
-        </SessionContext.Provider>
-      </MemoryRouter>,
+      <TestProvider>
+        <TopBar drawerOpen={drawerOpen} />
+      </TestProvider>,
       div
     );
   });


### PR DESCRIPTION
This is an extensive and unwarranted refactor of most the tests in the codebase. Basically, I abstracted the nested MemoryRouter, fake Session context, and fake Provider context into one component. One notable front-end change is that NameTag now gets its session value from context instead of props. After making that change, I figured out a way to pass in falsy fake sessions into TestProvider and have all the tests still pass. 

I know that refactors often come at the expense of legibility, so I'm open to criticism. 